### PR TITLE
fix: wait for tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
     if: needs.get-next-version.outputs.new-release-published == 'true'
     needs:
       - get-next-version
+      - release
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
do we have a dependency error, whereby the docker metadata runs before the tag is created? This was the behaviour in the actions menu.

Let's see it this resolves that